### PR TITLE
Update station config gen, plus automation

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "vue": "^2.3.3",
     "vue-electron": "^1.0.6",
     "vue-floatthead": "^0.0.5",
-    "vue-numeric": "^2.1.2",
     "vue-router": "^2.5.3",
     "vue-scrollto": "^2.7.2",
     "vue2-scrollspy": "^1.1.2",

--- a/src/renderer/components/Report/StreamflowCalculator.vue
+++ b/src/renderer/components/Report/StreamflowCalculator.vue
@@ -17,11 +17,11 @@
             <td>
               <input class="stream-input" :id="`TapeFt-${item.station}`" :value="item.tapeFt" @input="updateTapeFt(item.station)"></td>
             <td>
-              <vue-numeric v-bind:precision="2" class="stream-input" :id="`MaxDepth-${item.station}`" :value="item.maxDepth" @input="updateMaxDepth(item.station)"></vue-numeric></td>
+              <input class="stream-input" :id="`MaxDepth-${item.station}`" :value="item.maxDepth" @input="updateMaxDepth(item.station)"></td>
             <td>
-              <vue-numeric v-bind:precision="0" class="stream-input" :id="`Spins-${item.station}`" :value="item.spins" @input="updateSpins(item.station)"></vue-numeric></td>
+              <input class="stream-input" :id="`Spins-${item.station}`" :value="item.spins" @input="updateSpins(item.station)"></td>
             <td>
-              <vue-numeric v-bind:precision="1" class="stream-input" :id="`TimeSec-${item.station}`" :value="item.timeSec" @input="updateTimeSec(item.station)"></vue-numeric></td>
+              <input class="stream-input" :id="`TimeSec-${item.station}`" :value="item.timeSec" @input="updateTimeSec(item.station)"></td>
             <td>
               <textarea :id="`ReadingComments-${item.station}`" :value="item.readingComments" @input="updateReadingComments(item.station)"></textarea></td>
           </tr>
@@ -112,22 +112,31 @@
         })
       },
       updateMaxDepth (station) {
-        this.$store.commit('updateMaxDepth', {
-          station: station,
-          val: document.getElementById(`MaxDepth-${station}`).value
-        })
+        let val = document.getElementById(`MaxDepth-${station}`).value
+        if (!isNaN(val) || val === '') {
+          this.$store.commit('updateMaxDepth', {
+            station: station,
+            val: val * 1
+          })
+        }
       },
       updateSpins (station) {
-        this.$store.commit('updateSpins', {
-          station: station,
-          val: document.getElementById(`Spins-${station}`).value
-        })
+        let val = document.getElementById(`Spins-${station}`).value
+        if (!isNaN(val) || val === '') {
+          this.$store.commit('updateSpins', {
+            station: station,
+            val: val * 1
+          })
+        }
       },
       updateTimeSec (station) {
-        this.$store.commit('updateTimeSec', {
-          station: station,
-          val: document.getElementById(`TimeSec-${station}`).value
-        })
+        let val = document.getElementById(`TimeSec-${station}`).value
+        if (!isNaN(val) || val === '') {
+          this.$store.commit('updateTimeSec', {
+            station: station,
+            val: val * 1
+          })
+        }
       },
       updateReadingComments (station) {
         this.$store.commit('updateReadingComments', {

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -7,14 +7,12 @@ import store from './store'
 import FloatThead from 'vue-floatthead'
 import Scrollspy from 'vue2-scrollspy'
 import VueScrollTo from 'vue-scrollto'
-import VueNumeric from 'vue-numeric'
 
 Vue.use(VueScrollTo, {
   duration: 10
 })
 Vue.use(FloatThead)
 Vue.use(Scrollspy)
-Vue.use(VueNumeric)
 
 if (!process.env.IS_WEB) Vue.use(require('vue-electron'))
 Vue.http = Vue.prototype.$http = axios

--- a/src/renderer/store/modules/config.js
+++ b/src/renderer/store/modules/config.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const state = {
   sites: [],
   contacts: [],
-  setupSettings: { min: 4, max: 25 }
+  setupSettings: { min: 2, max: 27 }
 }
 
 const getters = {

--- a/src/renderer/util/csvGen.js
+++ b/src/renderer/util/csvGen.js
@@ -70,7 +70,7 @@ Flow Consistency:,${FLOW_CONSISTENCY},,Gauge Operating:,${GAUGE_OPERATING}
     const const2 = this.siteData.siteVisitSummary['Meter type'].const2
     const numerator = `E${st + 23}`
     const denom = `F${st + 23}`
-    return `=${const1}*(${numerator}/${denom})+${const2}`
+    return `=IF(${numerator}>0,${const1}*(${numerator}/${denom})+${const2},0)`
   }
   getStFt (st) {
     return `=C${st + 23} - C23`

--- a/src/renderer/util/index.js
+++ b/src/renderer/util/index.js
@@ -17,5 +17,21 @@ export default {
     const csv = new CsvGen(siteData, flowData, results)
     const report = csv.genReport()
     fs.writeFileSync(filename, report)
+  },
+  processFromMiddleOut: function (array) {
+    const newArray = []
+    let i = Math.ceil(array.length / 2)
+    let j = i + 1
+
+    while (i >= 0) {
+      newArray.push(array[j++])
+      if (i < array.length) newArray.push(array[i--])
+    }
+    return newArray
+  },
+  range: function* (begin, end, interval = 1) {
+    for (let i = begin; i < end; i += interval) {
+      yield i
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,13 +45,6 @@ accessibility-developer-tools@^2.11.0:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz#3da0cce9d6ec6373964b84f35db7cfc3df7ab514"
 
-accounting-js@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/accounting-js/-/accounting-js-1.1.1.tgz#7fe4b3f70c01ebe0b85c02c5f107f1393b880c9e"
-  dependencies:
-    is-string "^1.0.4"
-    object-assign "^4.0.1"
-
 acorn-dynamic-import@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz#c752bd210bef679501b6c6cb7fc84f8f47158cc4"
@@ -4205,10 +4198,6 @@ is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
-is-string@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.4.tgz#cc3a9b69857d621e963725a24caeec873b826e64"
-
 is-svg@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-2.1.0.tgz#cf61090da0d9efbcab8722deba6f032208dbb0e9"
@@ -7713,12 +7702,6 @@ vue-loader@^12.2.1:
     vue-hot-reload-api "^2.1.0"
     vue-style-loader "^3.0.0"
     vue-template-es2015-compiler "^1.2.2"
-
-vue-numeric@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/vue-numeric/-/vue-numeric-2.1.2.tgz#a96690e66b94a88665766ea2c1033852791e6042"
-  dependencies:
-    accounting-js "^1.1.1"
 
 vue-router@^2.5.3:
   version "2.7.0"


### PR DESCRIPTION
- Allow for flexible station config generation (spacing between last
  station and previous may be <= spacing between other stations)
- Auto-select closest station config to 15 stations (using middle-out
  array processing)
- Cleanup numerical inputs to lazily add prefixing 0 to decimals
- Remove dependency on vue-numeric package
- Update ftPerSec in generated csv output